### PR TITLE
Ignore $groups and $active_feature_flags 

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,8 @@ async function processEvent(event, { config }) {
 const flattenProperties = (props, sep, nestedChain = []) => {
     let newProps = {}
     for (const [key, value] of Object.entries(props)) {
-        if (key === '$elements') {
-            // Don't expand $elements on $autocapture events as those will be removed anyway
+        if (key === '$elements' || key === '$groups' || key === '$active_feature_flags') {
+            // Hide 'internal' properties used in event processing
         } else if (key === '$set') {
             newProps = { ...newProps, $set: { ...props[key], ...flattenProperties(props[key], sep) } }
         } else if (key === '$set_once') {


### PR DESCRIPTION
These (automatic) keys generate a bunch of noise in events without a clear benefit. Let's remove them.